### PR TITLE
Tests F&D reveal vs TBD

### DIFF
--- a/lib/tbd_tests/version.rb
+++ b/lib/tbd_tests/version.rb
@@ -29,5 +29,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module TBD_Tests
-  VERSION = "0.1.1".freeze
+  VERSION = "0.1.2".freeze
 end


### PR DESCRIPTION
Validates that subsurface vertex offsets (required for E+ Frame & Divider reveals) are generated by OpenStudio in the E+ forward translation, allowing TBD to safely process fenestration thermal bridging without a glitch. In response to this raised [issue](https://github.com/rd2/tbd/issues/97). No re-release of TBD itself is necessary.