### PR TITLE
Tests TBD v3.2.2 release candidate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "tbd", git: "https://github.com/rd2/tbd", branch: "uprated"
+gem "tbd", git: "https://github.com/rd2/tbd", branch: "develop"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "tbd", git: "https://github.com/rd2/tbd", branch: "develop"
+gem "tbd", git: "https://github.com/rd2/tbd", branch: "uprated"
 
 gemspec

--- a/lib/tbd_tests/version.rb
+++ b/lib/tbd_tests/version.rb
@@ -29,5 +29,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module TBD_Tests
-  VERSION = "0.1.4".freeze
+  VERSION = "0.1.5".freeze
 end

--- a/spec/tbd_osm_suite_spec.rb
+++ b/spec/tbd_osm_suite_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe TBD_Tests do
     # opts << "poor (BETBG)"
     # opts << "regular (BETBG)"
     # opts << "efficient (BETBG)"
-    # opts << "spandrel (BETBG)"
+    opts << "spandrel (BETBG)"
     opts << "spandrel HP (BETBG)"
     opts << "code (Quebec)"
     opts << "uncompliant (Quebec)"
@@ -78,6 +78,7 @@ RSpec.describe TBD_Tests do
       id    = "#{osm}_#{opt}".gsub(".", "_")
       dir   = File.join(runs, id)
       next if File.exist?(dir) && File.exist?(File.join(dir, "out.osw"))
+
       FileUtils.mkdir_p(dir)
       osw   = Marshal.load( Marshal.dump(template) )
 
@@ -89,8 +90,11 @@ RSpec.describe TBD_Tests do
       file    = File.join(dir, "in.osw")
       File.open(file, "w") { |f| f << JSON.pretty_generate(osw) }
       command = "'#{OpenStudio::getOpenStudioCLI}' run -w '#{file}'"
+      puts "... running CASE #{osm} | #{opt}"
       stdout, stderr, status = Open3.capture3(clean, command)
     end
+
+    puts
 
     osms.each do |osm|                   # fetch & compare E+ simulation results
       results = {}
@@ -110,10 +114,11 @@ RSpec.describe TBD_Tests do
         res  = results[opt][:steps][0][:result]
         os   = results[opt][:steps][1][:result]
         gj   = os[:step_values].select{ |v| v[:name] == "total_site_energy" }
-        puts " ------ TBD option  : #{opt}"
+        puts " ------       CASE  : #{osm}"
+        puts "        TBD option  : #{opt}"
         puts "        TBD success = #{res[:step_result]}"
         puts "         OS success = #{os[:step_result]}"
-        puts "  Total Site Energy = #{gj[0][:value]}"
+        puts "  Total Site Energy = #{gj[0][:value].to_i}"
       end
     end
   end

--- a/spec/tbd_prototype_suite_spec.rb
+++ b/spec/tbd_prototype_suite_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe TBD_Tests do
       id    = "#{type}_#{opt}"
       dir   = File.join(runs, id)
       next if File.exist?(dir) && File.exist?(File.join(dir, "out.osw"))
+
       FileUtils.mkdir_p(dir)
       osw   = Marshal.load( Marshal.dump(template) )
 
@@ -96,8 +97,11 @@ RSpec.describe TBD_Tests do
       file    = File.join(dir, "in.osw")
       File.open(file, "w") { |f| f << JSON.pretty_generate(osw) }
       command = "'#{OpenStudio::getOpenStudioCLI}' run -w '#{file}'"
+      puts "... running CASE #{osm} | #{opt}"
       stdout, stderr, status = Open3.capture3(clean, command)
     end
+
+    puts
 
     types.each do |type|                 # fetch & compare E+ simulation results
       results = {}
@@ -117,10 +121,11 @@ RSpec.describe TBD_Tests do
         res  = results[opt][:steps][1][:result]
         os   = results[opt][:steps][2][:result]
         gj   = os[:step_values].select{ |v| v[:name] == "total_site_energy" }
-        puts " ------ TBD option  : #{opt}"
+        puts " ------       CASE  : #{osm}"
+        puts "        TBD option  : #{opt}"
         puts "        TBD success = #{res[:step_result]}"
         puts "         OS success = #{os[:step_result]}"
-        puts "  Total Site Energy = #{gj[0][:value]}"
+        puts "  Total Site Energy = #{gj[0][:value].to_i}"
       end
     end
   end

--- a/spec/tbd_tests_spec.rb
+++ b/spec/tbd_tests_spec.rb
@@ -1721,7 +1721,7 @@ RSpec.describe TBD_Tests do
       expect(c.layers[2].nameString.include?("m tbd")).to be(true)
 
       next unless id.include?("_1_") # South
-      
+
       l_fenestration = 0
       l_head         = 0
       l_sill         = 0
@@ -8213,8 +8213,10 @@ RSpec.describe TBD_Tests do
       expect(layer.thermalResistance).to be_within(TOL).of(1.33) # m2.K/W (R7.6)
     end
 
-    # Set w1 as Bulk Storage Roof construction, which triggers a TBD error when
-    # uprating: safeguard limiting uprated constructions to single surface type.
+    # Set w1 (a wall construction) as the 'Bulk Storage Roof' construction. This
+    # triggers a TBD warning when uprating: a safeguard limiting uprated
+    # constructions to single surface type (e.g. can't be referenced by both
+    # roof AND wall surfaces).
     bulk = "Bulk Storage Roof"
     bulk_roof = os_model.getSurfaceByName(bulk)
     expect(bulk_roof.empty?).to be(false)
@@ -8241,9 +8243,9 @@ RSpec.describe TBD_Tests do
     expect(json.key?(:surfaces)).to be(true)
     io       = json[:io]
     surfaces = json[:surfaces]
-    expect(TBD.status).to eq(ERR)
+    expect(TBD.status).to eq(WRN)
     expect(TBD.logs.size).to eq(1)
-    msg = "Uprating wall, not '#{bulk}' (TBD::uprate)"
+    msg = "Cloning '#{bulk}' construction - not '#{w1}' (TBD::uprate)"
     expect(TBD.logs.first[:message]).to eq(msg)
     expect(io.nil?).to be(false)
     expect(io.is_a?(Hash)).to be(true)
@@ -8543,8 +8545,10 @@ RSpec.describe TBD_Tests do
       expect(layer.thermalResistance).to be_within(TOL).of(1.33) # m2.K/W (R7.6)
     end
 
-    # Set w1 as Bulk Storage Roof construction, which triggers a TBD error when
-    # uprating: safeguard limiting uprated constructions to single surface type.
+    # Set w1 (a wall construction) as the 'Bulk Storage Roof' construction. This
+    # triggers a TBD warning when uprating: a safeguard limiting uprated
+    # constructions to single surface type (e.g. can't be referenced by both
+    # roof AND wall surfaces).
     bulk = "Bulk Storage Roof"
     bulk_roof = os_model.getSurfaceByName(bulk)
     expect(bulk_roof.empty?).to be(false)
@@ -8571,9 +8575,9 @@ RSpec.describe TBD_Tests do
     expect(json.key?(:surfaces)).to be(true)
     io       = json[:io]
     surfaces = json[:surfaces]
-    expect(TBD.status).to eq(ERR)
+    expect(TBD.status).to eq(WRN)
     expect(TBD.logs.size).to eq(1)
-    msg = "Uprating wall, not '#{bulk}' (TBD::uprate)"
+    msg = "Cloning '#{bulk}' construction - not '#{w1}' (TBD::uprate)"
     expect(TBD.logs.first[:message]).to eq(msg)
     expect(io.nil?).to be(false)
     expect(io.is_a?(Hash)).to be(true)


### PR DESCRIPTION
TBD release candidate v3.2.2 fixes a bug when **uprating** (then _derating_) envelope surfaces separating **unconditioned** spaces (e.g. _insulated_ attic floors). Validation tests of the fix itself remain in the TBD test suite for this upcoming v3.2.2 release, but will likely transition to this testing repo in the future.

For this current set of tests, the changes only trigger a minor adjustment: catching a _warning_ (no longer an _error_) message when needing to clone constructions that aren't solely referenced by surfaces of a same type