### PR TITLE
Tests rimjoists vs plenums

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -111,8 +111,8 @@ jobs:
       run: |
         echo $(pwd)
         echo $(ls)
-        docker pull nrel/openstudio:dev-3.7.0-alpha
-        docker run --name test --rm -d -t -v $(pwd):/work -w /work nrel/openstudio:dev-3.7.0-alpha
+        docker pull nrel/openstudio:3.7.0
+        docker run --name test --rm -d -t -v $(pwd):/work -w /work nrel/openstudio:3.7.0
         docker exec -t test pwd
         docker exec -t test ls
         docker exec -t test bundle update

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "tbd", git: "https://github.com/rd2/tbd", branch: "develop"
+gem "tbd", git: "https://github.com/rd2/tbd", branch: "plenum"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "tbd", git: "https://github.com/rd2/tbd", branch: "plenum"
+gem "tbd", git: "https://github.com/rd2/tbd", branch: "develop"
 
 gemspec

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2020-2023, Denis Bourgeois & Dan Macumber
+Copyright (c) 2020-2024, Denis Bourgeois & Dan Macumber
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/json/tbd_z5.json
+++ b/json/tbd_z5.json
@@ -1,0 +1,12 @@
+{
+  "schema": "https://github.com/rd2/tbd/blob/master/tbd.schema.json",
+  "description": "testing TBD JSON for 5Zone (plenum)",
+  "psis": [{
+      "id": "salk",
+      "ceiling": 0.1
+  }],
+  "spaces": [{
+    "id": "PLENUM-1",
+    "psi": "salk"
+  }]
+}

--- a/lib/tbd_tests.rb
+++ b/lib/tbd_tests.rb
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 #
-# Copyright (c) 2020-2023, Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2024, Denis Bourgeois & Dan Macumber
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/tbd_tests/version.rb
+++ b/lib/tbd_tests/version.rb
@@ -29,5 +29,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module TBD_Tests
-  VERSION = "0.1.7".freeze # TBD Tests release version
+  VERSION = "0.1.8".freeze # TBD Tests release version
 end

--- a/lib/tbd_tests/version.rb
+++ b/lib/tbd_tests/version.rb
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 #
-# Copyright (c) 2020-2023, Denis Bourgeois & Dan Macumber
+# Copyright (c) 2020-2024, Denis Bourgeois & Dan Macumber
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/spec/tbd_tests_spec.rb
+++ b/spec/tbd_tests_spec.rb
@@ -11853,6 +11853,152 @@ RSpec.describe TBD_Tests do
     expect(attic.additionalProperties.resetFeature(key)).to be true
 
     # -- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- -- #
+    # 5Zone_2 test case (as INDIRECTLYCONDITIONED plenum).
+    plenum_walls   = []
+    plnum_walls    = ["WALL-1PB", "WALL-1PF", "WALL-1PL", "WALL-1PR"]
+    other_ceilings = ["C1-1", "C2-1", "C3-1", "C4-1", "C5-1"]
+
+    file  = File.join(__dir__, "files/osms/in/5Zone_2.osm")
+    path  = OpenStudio::Path.new(file)
+    model = translator.loadModel(path)
+    expect(model).to_not be_empty
+    model = model.get
+
+    # The model has valid thermostats.
+    heated = TBD.heatingTemperatureSetpoints?(model)
+    cooled = TBD.coolingTemperatureSetpoints?(model)
+    expect(heated).to be true
+    expect(cooled).to be true
+
+    plnum = model.getSpaceByName("PLENUM-1")
+    expect(plnum).to_not be_empty
+    plnum = plnum.get
+
+    # The plenum is more akin to an UNCONDITIONED attic (no thermostat).
+    expect(TBD.plenum?(plnum)).to be false
+    expect(TBD.unconditioned?(plnum)).to be true
+    expect(TBD.setpoints(plnum)[:heating]).to be_nil
+    expect(TBD.setpoints(plnum)[:cooling]).to be_nil
+    expect(TBD.status).to be_zero
+
+    argh  = { option: "uncompliant (Quebec)" }
+
+    json     = TBD.process(model, argh)
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:io)
+    expect(json).to have_key(:surfaces)
+    io       = json[:io      ]
+    surfaces = json[:surfaces]
+    expect(TBD.status).to be_zero
+    expect(TBD.logs).to be_empty
+    expect(surfaces).to be_a(Hash)
+    expect(surfaces.size).to eq(40)
+    expect(io).to be_a(Hash)
+    expect(io).to have_key(:edges)
+
+    # Plenum "walls" are not derated.
+    plnum_walls.each do |s|
+      expect(surfaces).to have_key(s)
+      expect(surfaces[s][:deratable]).to be false
+    end
+
+    # "Other" ceilings (i.e. those of conditioned spaces, adjacent to plenum
+    # "floors") are like insulated attic ceilings, and therefore derated.
+    other_ceilings.each do |s|
+      expect(surfaces).to have_key(s)
+      expect(surfaces[s][:deratable]).to be true
+    end
+
+    # There are no above-grade "rimjoists" identified by TBD:
+    expect(io[:edges].count { |edge| edge[:type] == :rimjoist      }).to eq(0)
+    expect(io[:edges].count { |edge| edge[:type] == :gradeconvex   }).to eq(8)
+    expect(io[:edges].count { |edge| edge[:type] == :parapetconvex }).to eq(4)
+
+    # --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
+    # Try again, yet first reset the plenum as INDIRECTLYCONDITIONED.
+    file  = File.join(__dir__, "files/osms/in/5Zone_2.osm")
+    path  = OpenStudio::Path.new(file)
+    model = translator.loadModel(path)
+    expect(model).to_not be_empty
+    model = model.get
+
+    plnum = model.getSpaceByName("PLENUM-1")
+    expect(plnum).to_not be_empty
+    plnum = plnum.get
+
+    key = "indirectlyconditioned"
+    val = "SPACE5-1"
+    expect(plnum.additionalProperties.setFeature(key, val)).to be true
+    expect(TBD.plenum?(plnum)).to be false
+    expect(TBD.unconditioned?(plnum)).to be false
+    expect(TBD.setpoints(plnum)[:heating]).to be_within(TOL).of(22.20)
+    expect(TBD.setpoints(plnum)[:cooling]).to be_within(TOL).of(23.90)
+    expect(TBD.status).to be_zero
+
+    argh  = { option: "uncompliant (Quebec)" }
+
+    json     = TBD.process(model, argh)
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:io)
+    expect(json).to have_key(:surfaces)
+    io       = json[:io      ]
+    surfaces = json[:surfaces]
+    expect(TBD.status).to be_zero
+    expect(TBD.logs).to be_empty
+    expect(surfaces).to be_a(Hash)
+    expect(surfaces.size).to eq(40)
+    expect(io).to be_a(Hash)
+    expect(io).to have_key(:edges)
+
+    # Plenum "walls" are now derated.
+    plnum_walls.each do |s|
+      expect(surfaces).to have_key(s)
+      expect(surfaces[s][:deratable]).to be true
+    end
+
+    # "Other" ceilings (i.e. those of conditioned spaces, adjacent to plenum
+    # "floors") are now like uninsulated suspended ceilings (no longer derated).
+    other_ceilings.each do |s|
+      expect(surfaces).to have_key(s)
+      expect(surfaces[s][:deratable]).to be false
+    end
+
+    # There are now above-grade "rimjoists", i.e. edge along suspended ceilings:
+    expect(io[:edges].count { |edge| edge[:type] == :rimjoist      }).to eq(4)
+    expect(io[:edges].count { |edge| edge[:type] == :gradeconvex   }).to eq(8)
+    expect(io[:edges].count { |edge| edge[:type] == :parapetconvex }).to eq(4)
+
+    io[:edges].each do |edge|
+      next unless edge[:type] == :rimjoist
+
+      plenum_wall = edge[:surfaces].select { |s| plnum_walls.include?(s) }
+      plenum_walls << plenum_wall.first
+    end
+
+    # Each of the :rimjoist edges is linked to 1x of the 4 plenum walls.
+    expect(plenum_walls.sort).to eq(plnum_walls.sort)
+
+    # There are (very) rare cases of INDIRECTLYCONDITIONED technical spaces
+    # (above occupied spaces) that have structural "floors" (not e.g. suspended
+    # ceiling tiles), supporting significant static and dynamic loads (e.g.
+    # Louis Kahn's Salk Institute). Yet for the vast majority of cases (e.g.
+    # return air plenums), we see simple suspended ceilings. Their perimeter
+    # edges do not thermally bridge (or derate) insulated building envelopes.
+    #
+    # We initially retained a laissez-faire approach with TBD regarding floors
+    # of INDIRECTLYCONDITIONED spaces (like plenums). Indeed, many (older?)
+    # OpenStudio models have plenum floors with reset surface types
+    # ("RoofCeiling"), which is sufficient for TBD to not tag such edges as
+    # "rimjoists", i.e. intermediate (structural) floor slabs. And TBD users
+    # could always override this default behaviour by specifying spacetype (or
+    # space) PSI factor sets (JSON inputs), with "rimjoists" of 0 W/K per meter.
+    #
+    # In hindsight, these workarounds imply additional steps for the vast
+    # majority of TBD users. The previous steps illustrate the current situation,
+    # which constitute the first step towards a revised solution (soonish).
+
+
+    # -- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- -- #
     # The following variations of the 'FullServiceRestaurant' (v3.2.1) are
     # snapshots of incremental development of the same model. For each step,
     # the tests illustrate how TBD ends up considering the unoccupied space

--- a/spec/tbd_tests_spec.rb
+++ b/spec/tbd_tests_spec.rb
@@ -12258,7 +12258,10 @@ RSpec.describe TBD_Tests do
     expect(TBD.setpoints(plnum)[:cooling]).to be_within(TOL).of(23.90)
     expect(TBD.status).to be_zero
 
-    argh  = { option: "uncompliant (Quebec)" }
+    file = File.join(__dir__, "files/osms/out/z5.osm")
+    model.save(file, true)
+
+    argh = { option: "uncompliant (Quebec)" }
 
     json     = TBD.process(model, argh)
     expect(json).to be_a(Hash)
@@ -12323,6 +12326,58 @@ RSpec.describe TBD_Tests do
     # but there remains only one per surface (a similar outcome to 'offset'
     # masonry shelf angles). Users are always free to curtomize TBD (via
     # JSON input) if needed.
+
+    # --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
+    # Test a custom non-0 "ceiling" PSI-factor.
+    file  = File.join(__dir__, "files/osms/out/z5.osm")
+    path  = OpenStudio::Path.new(file)
+    model = translator.loadModel(path)
+    expect(model).to_not be_empty
+    model = model.get
+
+    argh               = {}
+    argh[:option     ] = "uncompliant (Quebec)"
+    argh[:io_path    ] = File.join(__dir__, "../json/tbd_z5.json")
+    argh[:schema_path] = File.join(__dir__, "../tbd.schema.json")
+
+    json     = TBD.process(model, argh)
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:io)
+    expect(json).to have_key(:surfaces)
+    io       = json[:io      ]
+    surfaces = json[:surfaces]
+    expect(TBD.status).to be_zero
+    expect(TBD.logs).to be_empty
+    expect(surfaces).to be_a(Hash)
+    expect(surfaces.size).to eq(40)
+    expect(io).to be_a(Hash)
+    expect(io).to have_key(:edges)
+
+    # Plenum "walls" are (still) derated.
+    plnum_walls.each do |s|
+      expect(surfaces).to have_key(s)
+      expect(surfaces[s][:deratable]).to be true
+    end
+
+    # "Other" ceilings (i.e. those of conditioned spaces, adjacent to plenum
+    # "floors") are (still) no longer derated.
+    other_ceilings.each do |s|
+      expect(surfaces).to have_key(s)
+      expect(surfaces[s][:deratable]).to be false
+    end
+
+    io[:edges].select { |edge| edge[:type] == :ceiling }.each do |edge|
+      expect(edge[:psi]).to eq("salk")
+    end
+
+    expect(io[:edges].count { |edge| edge[:type] == :ceiling       }).to eq(4)
+    expect(io[:edges].count { |edge| edge[:type] == :rimjoist      }).to eq(0)
+    expect(io[:edges].count { |edge| edge[:type] == :gradeconvex   }).to eq(8)
+    expect(io[:edges].count { |edge| edge[:type] == :parapetconvex }).to eq(4)
+
+    out  = JSON.pretty_generate(io)
+    file = File.join(__dir__, "../json/tbd_z5.out.json")
+    File.open(file, "w") { |f| f.puts out }
 
 
     # -- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- -- #

--- a/spec/tbd_tests_spec.rb
+++ b/spec/tbd_tests_spec.rb
@@ -1867,7 +1867,7 @@ RSpec.describe TBD_Tests do
     expect(model).to_not be_empty
     model = model.get
 
-    argh = {option: "90.1.22|steel.m|default"}
+    argh = { option: "90.1.22|steel.m|default" }
 
     json     = TBD.process(model, argh)
     expect(json).to be_a(Hash)
@@ -2083,6 +2083,12 @@ RSpec.describe TBD_Tests do
     expect(model).to_not be_empty
     model = model.get
 
+    # Ensure the plenum is 'unoccupied', i.e. not part of the total floor area.
+    plnum = model.getSpaceByName("scrigno_plenum")
+    expect(plnum).to_not be_empty
+    plnum = plnum.get
+    expect(plnum.setPartofTotalFloorArea(false)).to be true
+
     # As a side test, switch glass doors to (opaque) doors.
     model.getSubSurfaces.each do |sub|
       next unless sub.subSurfaceType.downcase == "glassdoor"
@@ -2095,7 +2101,7 @@ RSpec.describe TBD_Tests do
     #    - "roof"    PSI-factor 0.02 W/K•m !!
     #
     # ... as per 90.1 2022 (non-"parapet" admisible thresholds are much lower).
-    argh = {option: "90.1.22|steel.m|default", parapet: false}
+    argh = { option: "90.1.22|steel.m|default", parapet: false }
 
     json     = TBD.process(model, argh)
     expect(json).to be_a(Hash)
@@ -4670,7 +4676,9 @@ RSpec.describe TBD_Tests do
 
   it "can process JSON surface KHI entries" do
     translator = OpenStudio::OSVersion::VersionTranslator.new
-    TBD.clean!
+    expect(TBD.reset(DBG)).to eq(DBG)
+    expect(TBD.level     ).to eq(DBG)
+    expect(TBD.clean!    ).to eq(DBG)
 
     # First, basic IO tests with invalid entries.
     k = TBD::KHI.new
@@ -11625,6 +11633,319 @@ RSpec.describe TBD_Tests do
     model.save(file, true)
   end
 
+  it "can test 5ZoneNoHVAC (failed) uprating" do
+    translator = OpenStudio::OSVersion::VersionTranslator.new
+    TBD.clean!
+
+    walls = []
+    id    = "ASHRAE 189.1-2009 ExtWall Mass ClimateZone 5"
+    file  = File.join(__dir__, "files/osms/in/5ZoneNoHVAC.osm")
+    path  = OpenStudio::Path.new(file)
+    model = translator.loadModel(path)
+    expect(model).to_not be_empty
+    model = model.get
+
+    # Get geometry data for testing (4x exterior walls, same construction).
+    construction = nil
+
+    model.getSurfaces.each do |s|
+      next unless s.surfaceType == "Wall"
+      next unless s.outsideBoundaryCondition == "Outdoors"
+
+      walls << s.nameString
+      c = s.construction
+      expect(c).to_not be_empty
+      c = c.get.to_LayeredConstruction
+      expect(c).to_not be_empty
+      c = c.get
+
+      construction = c if construction.nil?
+      expect(c).to eq(construction)
+    end
+
+    expect(walls.size              ).to eq( 4)
+    expect(construction.nameString ).to eq(id)
+    expect(construction.layers.size).to eq( 4)
+
+    insulation = construction.layers[2].to_StandardOpaqueMaterial
+    expect(insulation).to_not be_empty
+    insulation = insulation.get
+    expect(insulation.thickness).to be_within(0.0001).of(0.0794)
+    expect(insulation.thermalConductivity).to be_within(0.0001).of(0.0432)
+    original_r = insulation.thickness / insulation.thermalConductivity
+    expect(original_r).to be_within(TOL).of(1.8380)
+
+    argh = { option: "efficient (BETBG)" } # all PSI-factors @ 0.2 W/K•m
+
+    json     = TBD.process(model, argh)
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:io)
+    expect(json).to have_key(:surfaces)
+    io       = json[:io      ]
+    surfaces = json[:surfaces]
+    expect(TBD.status).to be_zero
+    expect(TBD.logs).to be_empty
+
+    walls.each do |wall|
+      expect(surfaces).to have_key(wall)
+      expect(surfaces[wall]).to have_key(:heatloss)
+
+      long  = (surfaces[wall][:heatloss] - 27.746).abs < TOL # 40 metres wide
+      short = (surfaces[wall][:heatloss] - 14.548).abs < TOL # 20 metres wide
+      expect(long || short).to be true
+    end
+
+    # The 4-sided model has 2x "long" front/back + 2x "short" side exterior
+    # walls, with a total TBD-calculated heat loss (from thermal bridging) of:
+    #
+    #   2x 27.746 W/K + 2x 14.548 W/K = ~84.588 W/K
+    #
+    # Spread over ~273.6 m2 of gross wall area, that is A LOT! Why (given the
+    # "efficient" PSI-factors)? Each wall has a long "strip" window, almost the
+    # full wall width (reaching to within a few millimetres of each corner).
+    # This ~slices the host wall into 2x very narrow strips. Although the
+    # thermal bridging details are considered "efficient", the total length of
+    # linear thermal bridges is very high given the limited exposed (gross)
+    # area. If area-weighted, derating the insulation layer of the referenced
+    # wall construction above would entail factoring in this extra thermal
+    # conductance of ~0.309 W/m2•K (84.6/273.6), which would reduce the
+    # insulation thickness quite significantly.
+    #
+    #   Ut = Uo + ( ∑psi • L )/A
+    #
+    # Expressed otherwise:
+    #
+    #   Ut = Uo + 0.309
+    #
+    # So what initial Uo factor should the construction offer (prior to
+    # derating) to ensure compliance with NECB2017/2020 prescriptive
+    # requirements (one of the few energy codes with prescriptive Ut
+    # requirements)? For climate zone 7, the target Ut is 0.210 W/m2•K (Rsi
+    # 4.76 m2•K/W or R27). Taking into account air film resistances and
+    # non-insulating layer resistances (e.g. ~Rsi 1 m2•K/W), the prescribed
+    # (max) layer Ut becomes ~0.277 (Rsi 3.6 or R20.5).
+    #
+    #   0.277 = Uo? + 0.309
+    #
+    # Duh-oh! Even with an infinitely thick insulation layer (Uo ~= 0), it
+    # would be impossible to reach NECB2017/2020 prescritive requirements with
+    # "efficient" thermal breaks. Solutions? Eliminate windows :\ Otherwise,
+    # further improve detailing as to achieve ~0.1 W/K per linear metre
+    # (easier said than done). Here, an average PSI-factor of 0.150 W/K per
+    # linear metre (i.e. ~76.1 W/K instead of ~84.6 W/K) still won't cut it
+    # for a Uo of 0.01 W/m2•K (Rsi 100 or R568). Instead, an average PSI-factor
+    # of 0.090 (~45.6 W/K, very high performance) would allow compliance for a
+    # Uo of 0.1 W/m2•K (Rsi 10 or R57, ... $$$).
+    #
+    # Long story short: there will inevitably be cases where TBD is unable to
+    # "uprate" a construction prior to "derating". This is neither a TBD bug
+    # nor an RP-1365/ISO model limitation. It is simply "bad" input, although
+    # likely unintentional. Nevertheless, TBD should exit in such cases with
+    # an ERROR message.
+    #
+    # And if one were to instead model each of the OpenStudio walls described
+    # above as 2x distinct OpenStudio surfaces? e.g.:
+    #   - 95% of exposed wall area Uo 0.01 W/m2•K
+    #   - 5% of exposed wall area as a "thermal bridge" strip (~5.6 W/m2•K *)
+    #
+    #     * (76.1 W/K over 5% of 273.6 m2)
+    #
+    # One would still consistently arrive at the same area-weighted average
+    # Ut, in this case 0.288 (> 0.277). No free lunches.
+    #
+    # ---
+    #
+    # TBD's "uprating" method reorders the equation and attempts the
+    # following:
+    #
+    #   Uo = 0.277 - ( ∑psi • L )/A
+    #
+    # The method exits with an ERROR in 2x cases:
+    #   - calculated Uo is negative, i.e. ( ∑psi • L )/A > 0.277
+    #   - calculated layer r violates E+ material constraints (e.g. too thin)
+
+    # -- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- -- #
+    # Retrying the previous example, yet requesting uprating calculations:
+    TBD.clean!
+
+    model = translator.loadModel(path)
+    expect(model).to_not be_empty
+    model = model.get
+
+    argh                = {}
+    argh[:option      ] = "efficient (BETBG)" # all PSI-factors @ 0.2 W/K•m
+    argh[:uprate_walls] = true
+    argh[:uprate_roofs] = true
+    argh[:wall_option ] = "ALL wall constructions"
+    argh[:roof_option ] = "ALL roof constructions"
+    argh[:wall_ut     ] = 0.210 # NECB CZ7 2017 (RSi 4.76 / R27)
+    argh[:roof_ut     ] = 0.138 # NECB CZ7 2017 (RSi 7.25 / R41)
+
+    json     = TBD.process(model, argh)
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:io)
+    expect(json).to have_key(:surfaces)
+    io       = json[:io      ]
+    surfaces = json[:surfaces]
+    expect(TBD.error?).to be true
+    expect(TBD.logs.size).to eq(2)
+    expect(TBD.logs.first[:message]).to include("Zero")
+    expect(TBD.logs.first[:message]).to include(": new Rsi")
+    expect(TBD.logs.last[ :message]).to include("Unable to uprate")
+
+    expect(argh).to_not have_key(:wall_uo)
+    expect(argh).to     have_key(:roof_uo)
+    expect(argh[:roof_uo]).to_not be_nil
+    expect(argh[:roof_uo]).to be_within(TOL).of(0.118) # RSi 8.47 (R48)
+
+    # -- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- -- #
+    # Final attempt, with PSI-factors of 0.09 W/K per linear metre (JSON file).
+    TBD.clean!
+
+    walls = []
+    model = translator.loadModel(path)
+    expect(model).to_not be_empty
+    model = model.get
+
+    argh                = {}
+    argh[:io_path     ] = File.join(__dir__, "../json/tbd_5ZoneNoHVAC.json")
+    argh[:schema_path ] = File.join(__dir__, "../tbd.schema.json")
+    argh[:uprate_walls] = true
+    argh[:uprate_roofs] = true
+    argh[:wall_option ] = "ALL wall constructions"
+    argh[:roof_option ] = "ALL roof constructions"
+    argh[:wall_ut     ] = 0.210 # NECB CZ7 2017 (RSi 4.76 / R27)
+    argh[:roof_ut     ] = 0.138 # NECB CZ7 2017 (RSi 7.25 / R41)
+
+    json      = TBD.process(model, argh)
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:io)
+    expect(json).to have_key(:surfaces)
+    io        = json[:io      ]
+    surfaces  = json[:surfaces]
+    expect(TBD.status).to be_zero
+
+    expect(argh).to have_key(:wall_uo)
+    expect(argh).to have_key(:roof_uo)
+    expect(argh[:wall_uo]).to_not be_nil
+    expect(argh[:roof_uo]).to_not be_nil
+    expect(argh[:wall_uo]).to be_within(TOL).of(0.086) # RSi 11.63 (R66)
+    expect(argh[:roof_uo]).to be_within(TOL).of(0.129) # RSi  7.75 (R44)
+
+    model.getSurfaces.each do |s|
+      next unless s.surfaceType == "Wall"
+      next unless s.outsideBoundaryCondition == "Outdoors"
+
+      walls << s.nameString
+      c = s.construction
+      expect(c).to_not be_empty
+      c = c.get.to_LayeredConstruction
+      expect(c).to_not be_empty
+      c = c.get
+
+      expect(c.nameString).to include(" c tbd")
+      expect(c.layers.size).to eq(4)
+
+      insul = c.layers[2].to_StandardOpaqueMaterial
+      expect(insul).to_not be_empty
+      insul = insul.get
+      expect(insul.nameString).to include(" uprated m tbd")
+
+      expect(insul.thermalConductivity).to be_within(0.0001).of(0.0432)
+      th1 = (insul.thickness - 0.191).abs < 0.001 # derated layer Rsi 4.42
+      th2 = (insul.thickness - 0.186).abs < 0.001 # derated layer Rsi 4.31
+      expect(th1 || th2).to be true # depending if 'short' or 'long' walls
+    end
+
+    walls.each do |wall|
+      expect(surfaces).to have_key(wall)
+      expect(surfaces[wall]).to have_key(:r) # uprated, non-derated layer Rsi
+      expect(surfaces[wall]).to have_key(:u) # uprated, non-derated assembly
+      expect(surfaces[wall][:r]).to be_within(0.001).of(11.205) # R64
+      expect(surfaces[wall][:u]).to be_within(0.001).of( 0.086) # R66
+    end
+
+    # -- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- -- #
+    # Realistic, BTAP-costed PSI-factors.
+    TBD.clean!
+
+    jpath = "../json/tbd_5ZoneNoHVAC_btap.json"
+    file  = File.join(__dir__, "files/osms/in/5ZoneNoHVAC.osm")
+    path  = OpenStudio::Path.new(file)
+    model = translator.loadModel(path)
+    expect(model).to_not be_empty
+    model = model.get
+
+    # Assign (missing) space types.
+    north = model.getSpaceByName("Story 1 North Perimeter Space")
+    east  = model.getSpaceByName("Story 1 East Perimeter Space")
+    south = model.getSpaceByName("Story 1 South Perimeter Space")
+    west  = model.getSpaceByName("Story 1 West Perimeter Space")
+    core  = model.getSpaceByName("Story 1 Core Space")
+
+    expect(north).to_not be_empty
+    expect(east ).to_not be_empty
+    expect(south).to_not be_empty
+    expect(west ).to_not be_empty
+    expect(core ).to_not be_empty
+
+    north = north.get
+    east  = east.get
+    south = south.get
+    west  = west.get
+    core  = core.get
+
+    audience  = OpenStudio::Model::SpaceType.new(model)
+    warehouse = OpenStudio::Model::SpaceType.new(model)
+    offices   = OpenStudio::Model::SpaceType.new(model)
+    sales     = OpenStudio::Model::SpaceType.new(model)
+    workshop  = OpenStudio::Model::SpaceType.new(model)
+
+    audience.setName("Audience - auditorium")
+    warehouse.setName("Warehouse - fine")
+    offices.setName("Office - enclosed")
+    sales.setName("Sales area")
+    workshop.setName("Workshop space")
+
+    expect(north.setSpaceType(audience )).to be true
+    expect( east.setSpaceType(warehouse)).to be true
+    expect(south.setSpaceType(offices  )).to be true
+    expect( west.setSpaceType(sales    )).to be true
+    expect( core.setSpaceType(workshop )).to be true
+
+    argh                = {}
+    argh[:io_path     ] = File.join(__dir__, jpath)
+    argh[:schema_path ] = File.join(__dir__, "../tbd.schema.json")
+    argh[:uprate_walls] = true
+    argh[:wall_option ] = "ALL wall constructions"
+    argh[:wall_ut     ] = 0.210 # NECB CZ7 2017 (RSi 4.76 / R41)
+
+    TBD.process(model, argh)
+    expect(argh).to_not have_key(:roof_uo)
+
+    # OpenStudio prior to v3.5.X had a 3m maximum layer thickness, reflecting a
+    # previous v8.8 EnergyPlus constraint. TBD caught such cases when uprating
+    # (as per NECB requirements). From v3.5.0+, OpenStudio dropped the maximum
+    # layer thickness limit, harmonizing with EnergyPlus:
+    #
+    #   https://github.com/NREL/OpenStudio/pull/4622
+    if OpenStudio.openStudioVersion.split(".").join.to_i < 350
+      expect(TBD.error?).to be true
+      expect(TBD.logs).to_not be_empty
+      expect(TBD.logs.size).to eq(2)
+
+      expect(TBD.logs.first[:message]).to include("Invalid")
+      expect(TBD.logs.first[:message]).to include("Can't uprate ")
+      expect(TBD.logs.last[:message ]).to include("Unable to uprate")
+
+      expect(argh).to_not have_key(:wall_uo)
+    else
+      expect(TBD.status).to be_zero
+      expect(argh).to have_key(:wall_uo)
+      expect(argh[:wall_uo]).to be_within(0.0001).of(0.0089) # RSi 112 (R638)
+    end
+  end
+
   it "can test Hash inputs" do
     translator = OpenStudio::OSVersion::VersionTranslator.new
     TBD.clean!
@@ -11922,9 +12243,11 @@ RSpec.describe TBD_Tests do
     expect(model).to_not be_empty
     model = model.get
 
+    # Ensure the plenum is 'unoccupied', i.e. not part of the total floor area.
     plnum = model.getSpaceByName("PLENUM-1")
     expect(plnum).to_not be_empty
     plnum = plnum.get
+    expect(plnum.setPartofTotalFloorArea(false)).to be true
 
     key = "indirectlyconditioned"
     val = "SPACE5-1"
@@ -11963,20 +12286,12 @@ RSpec.describe TBD_Tests do
       expect(surfaces[s][:deratable]).to be false
     end
 
-    # There are now above-grade "rimjoists", i.e. edge along suspended ceilings:
-    expect(io[:edges].count { |edge| edge[:type] == :rimjoist      }).to eq(4)
+    # Prior to v3.4.0, plenum floors would have been tagged as "rimjoists". No
+    # longer the case ("ceilings" are caught earlier in the process).
+    expect(io[:edges].count { |edge| edge[:type] == :ceiling       }).to eq(4)
+    expect(io[:edges].count { |edge| edge[:type] == :rimjoist      }).to eq(0)
     expect(io[:edges].count { |edge| edge[:type] == :gradeconvex   }).to eq(8)
     expect(io[:edges].count { |edge| edge[:type] == :parapetconvex }).to eq(4)
-
-    io[:edges].each do |edge|
-      next unless edge[:type] == :rimjoist
-
-      plenum_wall = edge[:surfaces].select { |s| plnum_walls.include?(s) }
-      plenum_walls << plenum_wall.first
-    end
-
-    # Each of the :rimjoist edges is linked to 1x of the 4 plenum walls.
-    expect(plenum_walls.sort).to eq(plnum_walls.sort)
 
     # There are (very) rare cases of INDIRECTLYCONDITIONED technical spaces
     # (above occupied spaces) that have structural "floors" (not e.g. suspended
@@ -11985,17 +12300,29 @@ RSpec.describe TBD_Tests do
     # return air plenums), we see simple suspended ceilings. Their perimeter
     # edges do not thermally bridge (or derate) insulated building envelopes.
     #
-    # We initially retained a laissez-faire approach with TBD regarding floors
-    # of INDIRECTLYCONDITIONED spaces (like plenums). Indeed, many (older?)
-    # OpenStudio models have plenum floors with reset surface types
-    # ("RoofCeiling"), which is sufficient for TBD to not tag such edges as
-    # "rimjoists", i.e. intermediate (structural) floor slabs. And TBD users
-    # could always override this default behaviour by specifying spacetype (or
-    # space) PSI factor sets (JSON inputs), with "rimjoists" of 0 W/K per meter.
+    # Prior to v3.4.0, we initially retained a laissez-faire approach with TBD
+    # regarding floors of INDIRECTLYCONDITIONED spaces (like plenums). Indeed,
+    # many (older?) OpenStudio models have plenum floors with 'reset' surface
+    # types ("RoofCeiling"), which was sufficient for TBD to not tag such edges
+    # as "rimjoists", i.e. intermediate (structural) floor slabs. Sure, TBD
+    # users could always override this default behaviour by specifying spacetype
+    # -specific PSI factor sets (JSON inputs), with "rimjoists" of 0 W/K per
+    # meter. Yet these workarounds necessarily implied additional steps for the
+    # vast majority of TBD users. As of v3.4.0, the default automated TBD
+    # outcome is to tag plenum "floors" as "ceilings" (no additional steps).
     #
-    # In hindsight, these workarounds imply additional steps for the vast
-    # majority of TBD users. The previous steps illustrate the current situation,
-    # which constitute the first step towards a revised solution (soonish).
+    # The flip side is that additional consideration may be required for less
+    # common cases involving plenums. Take for instance underfloor air supply
+    # plenums. The carpeted floors building occupants actually walk on are not
+    # structural concrete slabs (the perimeter edges of which would constitute
+    # common thermal bridges, i.e. "rimjoists"). By default, TBD will now tag
+    # the raised floor as a structural "floor" (with associated thermal
+    # bridging) and instead tag the actual structural slab as "ceiling".
+    # Although this doesn't sound OK initially, this works out just fine for
+    # most cases: the "rimjoist" edge may not line up perfectly (vertically),
+    # but there remains only one per surface (a similar outcome to 'offset'
+    # masonry shelf angles). Users are always free to curtomize TBD (via
+    # JSON input) if needed.
 
 
     # -- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- -- #

--- a/tbd.schema.json
+++ b/tbd.schema.json
@@ -122,6 +122,18 @@
           "title": "Convex (other than parapet/overhang) roof/wall edge PSI",
           "type": "number"
         },
+        "ceiling": {
+          "title": "Intermediate ceiling (not floor) edge PSI",
+          "type": "number"
+        },
+        "ceilingconcave": {
+          "title": "Concave intermediate ceiling (not floor) edge PSI",
+          "type": "number"
+        },
+        "ceilingconvex": {
+          "title": "Convex intermediate ceiling (not floor) edge PSI",
+          "type": "number"
+        },
         "fenestration": {
           "title": "Window or glazed door perimeter PSI",
           "type": "number"
@@ -369,6 +381,9 @@
             "roof",
             "roofconcave",
             "roofconvex",
+            "ceiling",
+            "ceilingconcave",
+            "ceilingconvex",
             "fenestration",
             "head",
             "headconcave",

--- a/tbd_tests.gemspec
+++ b/tbd_tests.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version    = [">= 2.5.0", "< 3"]
   s.metadata                 = {}
 
+  s.add_development_dependency "tbd",            "~> 3.4.0"
   s.add_development_dependency "json-schema",    "~> 2.7.0"
   s.add_development_dependency "bundler",        "~> 2.1"
   s.add_development_dependency "rake",           "~> 13.0"


### PR DESCRIPTION
In the vast majority of buildings, _indirectly-conditioned_ spaces (like return air plenums) have "floors" that aren't _structural_, e.g. suspended ceiling tiles (the perimeter of which rarely constitutes a thermal bridge). There are workarounds to avoid tagging plenum ceilings as "floors" (either on the OpenStudio side, or through TBD JSON customization), but these almost always end up burdening the typical OpenStudio/TBD user.

This commit/PR is a first step towards remediating the issue.