### PR TITLE
Tests JSON schema v4 upgrade

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -118,3 +118,19 @@ jobs:
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
         docker kill test
+  test_380x:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Run Tests
+      run: |
+        echo $(pwd)
+        echo $(ls)
+        docker pull nrel/openstudio:3.8.0
+        docker run --name test --rm -d -t -v $(pwd):/work -w /work nrel/openstudio:3.8.0
+        docker exec -t test pwd
+        docker exec -t test ls
+        docker exec -t test bundle update
+        docker exec -t test bundle exec rake
+        docker kill test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -118,7 +118,7 @@ jobs:
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
         docker kill test
-  test_380x:
+test_380x:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out repository
@@ -131,7 +131,6 @@ jobs:
         docker run --name test --rm -d -t -v $(pwd):/work -w /work nrel/openstudio:3.8.0
         docker exec -t test pwd
         docker exec -t test ls
-        bundle config set --local without openstudio_prerelease
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
         docker kill test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -118,7 +118,7 @@ jobs:
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
         docker kill test
-test_380x:
+  test_380x:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out repository

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
-source "https://rubygems.org"
+# source "https://rubygems.org"
 
-gem "tbd", git: "https://github.com/rd2/tbd", branch: "develop"
+gem "tbd", git: "https://github.com/jmarrec/tbd", branch: "json_schema"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,5 @@
 source "https://rubygems.org"
 
-gem "tbd", git: "https://github.com/rd2/tbd", branch: "json"
-
-group :openstudio_prerelease, optional: true do
-  gem "openstudio-common-measures", git: "https://github.com/NREL/openstudio-common-measures-gem", branch: "0.10.0-rc1"
-  gem "openstudio-model-articulation", git: "https://github.com/NREL/openstudio-model-articulation-gem", branch: "0.10.0-rc2"
-end
+gem "tbd", git: "https://github.com/rd2/tbd", branch: "develop"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
-# source "https://rubygems.org"
+source "https://rubygems.org"
 
-gem "tbd", git: "https://github.com/jmarrec/tbd", branch: "json_schema"
+gem "tbd", git: "https://github.com/rd2/tbd", branch: "json"
 
 gemspec

--- a/lib/tbd_tests/version.rb
+++ b/lib/tbd_tests/version.rb
@@ -29,5 +29,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module TBD_Tests
-  VERSION = "0.2.0".freeze # TBD Tests release version
+  VERSION = "0.2.1".freeze # TBD Tests release version
 end

--- a/spec/tbd_tests_spec.rb
+++ b/spec/tbd_tests_spec.rb
@@ -14260,8 +14260,8 @@ RSpec.describe TBD_Tests do
     # 5x edges (instead of original 4x).
     expect(trsm_heads).to eq(1)
     expect(trsm_sills).to be_zero # instead shared with door and sidelight
-    expect(trsm_jambs).to eq(2) # 1x full height + 1x partial height
-    expect(trsm_trns ).to eq(2) # shared with sidelight + door
+    expect(trsm_jambs).to eq(2)   # 1x full height + 1x partial height
+    expect(trsm_trns ).to eq(2)   # shared with sidelight + door
 
     expect(trsm_jamb_m).to be_within(TOL).of(2 * 0.4          )
     expect(trsm_trns_m).to be_within(TOL).of(maxY - minY + 0.5)

--- a/tbd_tests.gemspec
+++ b/tbd_tests.gemspec
@@ -27,9 +27,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version    = [">= 2.5.0", "< 4"]
   s.metadata                 = {}
 
-  s.add_development_dependency "tbd",            "3.4.1"
+  s.add_development_dependency "tbd",            "3.4.2"
   s.add_development_dependency "json-schema", "~> 4"
-  s.add_development_dependency "bundler",     "~> 2.1"
   s.add_development_dependency "rake",        "~> 13.0"
   s.add_development_dependency "rspec",       "~> 3.11"
   s.add_development_dependency "parallel",    "~> 1.19"
@@ -37,18 +36,24 @@ Gem::Specification.new do |s|
   if /^2.5/.match(RUBY_VERSION)
     s.required_ruby_version = "~> 2.5.0"
 
+    s.add_development_dependency "bundler",     "~> 2.1"
+
     s.add_development_dependency "openstudio-common-measures",    "~> 0.2.1"
     s.add_development_dependency "openstudio-model-articulation", "~> 0.2.1"
   elsif /^2.7/.match(RUBY_VERSION)
     s.required_ruby_version = "~> 2.7.0"
 
+    s.add_development_dependency "bundler",     "~> 2.1"
+
     s.add_development_dependency "openstudio-common-measures",    "~> 0.5.0"
     s.add_development_dependency "openstudio-model-articulation", "~> 0.5.0"
   else
-    s.required_ruby_version = "~> 3.2.0"
+    s.required_ruby_version = "~> 3.2.2"
 
-    #s.add_development_dependency "openstudio-common-measures",    "~> 0.10.0"
-    #s.add_development_dependency "openstudio-model-articulation", "~> 0.10.0"
+    s.add_development_dependency "bundler",     "~> 2.4.10"
+
+    s.add_development_dependency "openstudio-common-measures",    "~> 0.10.0"
+    s.add_development_dependency "openstudio-model-articulation", "~> 0.10.0"
   end
 
   s.metadata["homepage_uri"   ] = s.homepage

--- a/tbd_tests.gemspec
+++ b/tbd_tests.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.metadata                 = {}
 
   s.add_development_dependency "tbd",            "3.4.1"
-  s.add_development_dependency "json-schema", "~> 2.7.0"
+  s.add_development_dependency "json-schema", "~> 4"
   s.add_development_dependency "bundler",     "~> 2.1"
   s.add_development_dependency "rake",        "~> 13.0"
   s.add_development_dependency "rspec",       "~> 3.11"


### PR DESCRIPTION
Linked to @jmarrec's [PR](https://github.com/rd2/tbd/pull/116) to upgrade json_schema to v4. Previous v2.7 (i.e. any version < 3) had been maintained to ensure compatibility with OpenStudio v2.9.1 ... which we no longer support. All tests are green locally.