### PR TITLE
Try to get this working with prereleases

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -131,6 +131,7 @@ jobs:
         docker run --name test --rm -d -t -v $(pwd):/work -w /work nrel/openstudio:3.8.0
         docker exec -t test pwd
         docker exec -t test ls
+        bundle config set --local without openstudio_prerelease
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
         docker kill test

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,9 @@ source "https://rubygems.org"
 
 gem "tbd", git: "https://github.com/rd2/tbd", branch: "json"
 
+group :openstudio_prerelease, optional: true do
+  gem "openstudio-common-measures", git: "https://github.com/NREL/openstudio-common-measures-gem", branch: "0.10.0-rc1"
+  gem "openstudio-model-articulation", git: "https://github.com/NREL/openstudio-model-articulation-gem", branch: "0.10.0-rc2"
+end
+
 gemspec

--- a/tbd_tests.gemspec
+++ b/tbd_tests.gemspec
@@ -32,18 +32,23 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler",     "~> 2.1"
   s.add_development_dependency "rake",        "~> 13.0"
   s.add_development_dependency "rspec",       "~> 3.11"
-  s.add_development_dependency "parallel",    "~> 1.19.2"
+  s.add_development_dependency "parallel",    "~> 1.19"
 
   if /^2.5/.match(RUBY_VERSION)
     s.required_ruby_version = "~> 2.5.0"
 
     s.add_development_dependency "openstudio-common-measures",    "~> 0.2.1"
     s.add_development_dependency "openstudio-model-articulation", "~> 0.2.1"
-  else
+  elsif /^2.7/.match(RUBY_VERSION)
     s.required_ruby_version = "~> 2.7.0"
 
     s.add_development_dependency "openstudio-common-measures",    "~> 0.5.0"
     s.add_development_dependency "openstudio-model-articulation", "~> 0.5.0"
+  else
+    s.required_ruby_version = "~> 3.2.0"
+
+    #s.add_development_dependency "openstudio-common-measures",    "~> 0.10.0"
+    #s.add_development_dependency "openstudio-model-articulation", "~> 0.10.0"
   end
 
   s.metadata["homepage_uri"   ] = s.homepage


### PR DESCRIPTION
The current CI is failing for OpenStudio 3.8.0 because the following gems have not been released for 3.8.0 yet.  I tried to get this working using these branches but these branches aren't working yet:

https://github.com/NREL/openstudio-model-articulation-gem/pull/138/files
https://github.com/NREL/openstudio-common-measures-gem/pull/169/files

I think you'd need to coordinate with @DavidGoldwasser to make sure those branches work for TBD.  The main issue I see is that they are overly restrictive in their requirements.  That makes it hard to use these gems in other gems (like tbd_tests).