### PR TITLE
Checks impact of fixed SEB model

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+      - seb
 
 jobs:
   test_300x:
@@ -21,6 +22,7 @@ jobs:
         docker exec -t test ls
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
+        docker exec -t test bundle exec rake suites_run
         docker kill test
   test_321x:
     runs-on: ubuntu-22.04
@@ -37,6 +39,7 @@ jobs:
         docker exec -t test ls
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
+        docker exec -t test bundle exec rake suites_run
         docker kill test
   test_330x:
     runs-on: ubuntu-22.04
@@ -53,6 +56,7 @@ jobs:
         docker exec -t test ls
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
+        docker exec -t test bundle exec rake suites_run
         docker kill test
   test_340x:
     runs-on: ubuntu-22.04
@@ -69,6 +73,7 @@ jobs:
         docker exec -t test ls
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
+        docker exec -t test bundle exec rake suites_run
         docker kill test
   test_351x:
     runs-on: ubuntu-22.04
@@ -85,6 +90,7 @@ jobs:
         docker exec -t test ls
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
+        docker exec -t test bundle exec rake suites_run
         docker kill test
   test_361x:
     runs-on: ubuntu-22.04
@@ -101,6 +107,7 @@ jobs:
         docker exec -t test ls
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
+        docker exec -t test bundle exec rake suites_run
         docker kill test
   test_370x:
     runs-on: ubuntu-22.04
@@ -117,6 +124,7 @@ jobs:
         docker exec -t test ls
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
+        docker exec -t test bundle exec rake suites_run
         docker kill test
   test_380x:
     runs-on: ubuntu-22.04
@@ -133,4 +141,5 @@ jobs:
         docker exec -t test ls
         docker exec -t test bundle update
         docker exec -t test bundle exec rake
+        docker exec -t test bundle exec rake suites_run
         docker kill test

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
-gem "tbd", git: "https://github.com/rd2/tbd", branch: "develop"
+gem "tbd", git: "https://github.com/rd2/tbd", branch: "seb"
+gem "osut", git: "https://github.com/rd2/osut", branch: "sky"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
 gem "tbd", git: "https://github.com/rd2/tbd", branch: "seb"
-gem "osut", git: "https://github.com/rd2/osut", branch: "sky"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "tbd", git: "https://github.com/rd2/tbd", branch: "seb"
+gem "tbd", git: "https://github.com/rd2/tbd", branch: "develop"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -49,6 +49,10 @@ namespace "osm_suite" do
     puts "Cleaning TBD OSM Test Suite"
     osm = File.join(__dir__, "spec/osm_suite_runs")
     FileUtils.rmtree(osm)                                     if Dir.exist?(osm)
+    osm = File.join(__dir__, "spec/files/measures/openstudio_results")
+    FileUtils.rmtree(osm)                                     if Dir.exist?(osm)
+    tbd = File.join(__dir__, "spec/files/measures/tbd")
+    FileUtils.rmtree(tbd)                                     if Dir.exist?(tbd)
   end
 
   desc "Run TBD OSM Test Suite"
@@ -63,6 +67,8 @@ namespace "prototype_suite" do
   task :clean do
     puts "Cleaning Prototype Test Suite"
     pro = File.join(__dir__, "spec/prototype_suite_runs")
+    FileUtils.rmtree(pro)                                     if Dir.exist?(pro)
+    pro = File.join(__dir__, "spec/files/measures/create_DOE_prototype_building")
     FileUtils.rmtree(pro)                                     if Dir.exist?(pro)
   end
 

--- a/lib/measures/tbd_monkey_patch/LICENSE.md
+++ b/lib/measures/tbd_monkey_patch/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2024 Denis Bourgeois & Dan Macumber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/measures/tbd_monkey_patch/measure.rb
+++ b/lib/measures/tbd_monkey_patch/measure.rb
@@ -1,0 +1,93 @@
+# MIT License
+#
+# Copyright (c) 2020-2024 Denis Bourgeois & Dan Macumber
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+require 'openstudio-standards'
+
+if OpenstudioStandards::VERSION >= '0.6.0' and OpenstudioStandards::VERSION <= '0.6.3'
+  module OpenstudioStandards
+    # Patch this method to work with local files for due to bug fixed in:
+    # https://github.com/NREL/openstudio-standards/pull/1816
+    module Weather
+      def self.get_standards_weather_file_path(weather_file_name)
+        # Define where the weather files lives
+        top_dir = File.expand_path('../../..', File.dirname(__FILE__))
+        weather_dir = File.expand_path("#{top_dir}/spec/files/epws")
+
+        # Add Weather File
+        unless (Pathname.new weather_dir).absolute?
+          weather_dir = File.expand_path(File.join(File.dirname(__FILE__), weather_dir))
+        end
+        weather_file_path = File.join(weather_dir, weather_file_name)
+        return weather_file_path
+      end
+    end
+  end
+end
+
+class TBDMonkeyPatch < OpenStudio::Measure::ModelMeasure
+  ##
+  # Returns TBDMonkeyPatch identifier.
+  #
+  # @return [String] TBDMonkeyPatch identifier
+  def name
+    return "TBD Monkey Patch"
+  end
+
+  ##
+  # Returns TBDMonkeyPatch description.
+  #
+  # @return [String] TBDMonkeyPatch description
+  def description
+    return "Patch bugs in OpenStudio Measures."
+  end
+
+  ##
+  # Returns TBDMonkeyPatch modeler description.
+  #
+  # @return [String] TBDMonkeyPatch modeler description
+  def modeler_description
+    return "Check out rd2.github.io/tbd"
+  end
+
+  ##
+  # Returns processed/validated TBDMonkeyPatch arguments.
+  #
+  # @param model [OpenStudio::Model::Model] a model
+  #
+  # @return [OpenStudio::Measure::OSArgumentVector] validated arguments
+  def arguments(model = nil)
+    args = OpenStudio::Measure::OSArgumentVector.new
+    args
+  end
+
+  ##
+  # Runs the TBDMonkeyPatch Measure.
+  #
+  # @return [Bool] whether TBDMonkeyPatch is successful
+  def run(mdl, runner, args)
+    super(mdl, runner, args)
+    return true
+  end
+end
+
+# register the measure to be used by the application
+#TBDMonkeyPatch.new.registerWithApplication

--- a/lib/measures/tbd_monkey_patch/measure.xml
+++ b/lib/measures/tbd_monkey_patch/measure.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>tbd_monkey_patch</name>
+  <uid>8890787b-8c25-4dc8-8641-b6be1b6c2357</uid>
+  <version_id>26133940-6648-4a95-9e20-abb460d95376</version_id>
+  <version_modified>2024-10-12T01:51:16Z</version_modified>
+  <xml_checksum>99772807</xml_checksum>
+  <class_name>TBDMonkeyPatch</class_name>
+  <display_name>TBD Monkey Patch</display_name>
+  <description>Patch bugs in OpenStudio Measures.</description>
+  <modeler_description>Check out rd2.github.io/tbd</modeler_description>
+  <arguments />
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Envelope.Opaque</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ModelMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>Apply Measure Now</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>OpenStudio Application</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>Parametric Analysis Tool</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Use Case</name>
+      <value>Model Articulation</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Use Case</name>
+      <value>Calibration</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Use Case</name>
+      <value>Sensitivity Analysis</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Use Case</name>
+      <value>New Construction EE</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Use Case</name>
+      <value>Retrofit EE</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <filename>LICENSE.md</filename>
+      <filetype>md</filetype>
+      <usage_type>license</usage_type>
+      <checksum>5C9BFB50</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.9.1</identifier>
+        <min_compatible>2.9.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>1B746F62</checksum>
+    </file>
+  </files>
+</measure>

--- a/lib/tbd_tests.rb
+++ b/lib/tbd_tests.rb
@@ -27,28 +27,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-require "openstudio"
-
-require "topolys"
-require "oslg"
-require "osut"
-require "psi"
-require "geo"
-require "ua"
-require "tbd_tests/version"
-
-module TBD_Tests
-  extend TBD
-
-  TOL  = TBD::TOL     # default distance tolerance (m)
-  TOL2 = TBD::TOL2    # default area tolerance (m2)
-  DBG  = TBD::DEBUG   # github.com/rd2/oslg
-  INF  = TBD::INFO    # github.com/rd2/oslg
-  WRN  = TBD::WARN    # github.com/rd2/oslg
-  ERR  = TBD::ERR     # github.com/rd2/oslg
-  FTL  = TBD::FATAL   # github.com/rd2/oslg
-  NS   = "nameString" # OpenStudio IdfObject nameString method
-
-  extend TBD
-end

--- a/lib/tbd_tests/version.rb
+++ b/lib/tbd_tests/version.rb
@@ -29,5 +29,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module TBD_Tests
-  VERSION = "0.2.1".freeze # TBD Tests release version
+  VERSION = "0.2.2".freeze # TBD Tests release version
 end

--- a/spec/files/epws/USA_TX_El.Paso.Intl.AP.722700_TMY3.ddy
+++ b/spec/files/epws/USA_TX_El.Paso.Intl.AP.722700_TMY3.ddy
@@ -1,0 +1,536 @@
+ ! The following Location and Design Day data are produced as possible from the indicated data source.
+ ! Wind Speeds follow the indicated design conditions rather than traditional values (6.7 m/s heating, 3.35 m/s cooling)
+ ! No special attempts at re-creating or determining missing data parts (e.g. Wind speed or direction)
+ ! are done.  Therefore, you should look at the data and fill in any incorrect values as you desire.
+  
+ Site:Location,
+  El Paso International Ap  Ut_TX_USA Design_Conditions,     !- Location Name
+      31.77,     !- Latitude {N+ S-}
+    -106.50,     !- Longitude {W- E+}
+      -7.00,     !- Time Zone Relative to GMT {GMT+/-}
+    1186.00;     !- Elevation {m}
+ 
+ !  WMO=722700 Time Zone=NAM: (GMT-07:00) Mountain Time (US & Canada)
+ !  Data Source=ASHRAE 2009 Annual Design Conditions
+ RunPeriodControl:DaylightSavingTime,
+   2nd Sunday in March,    !- StartDate
+   2nd Sunday in November;    !- EndDate
+  
+ ! Using Design Conditions from "Climate Design Data 2009 ASHRAE Handbook"
+ ! El Paso International Ap  Ut_TX_USA Extreme Annual Wind Speeds, 1%=11.4m/s, 2.5%=9.3m/s, 5%=8.1m/s
+ ! El Paso International Ap  Ut_TX_USA Extreme Annual Temperatures, Max Drybulb=-8.9°C Min Drybulb=40.4°C
+  
+ ! El Paso International Ap  Ut_TX_USA Annual Heating Design Conditions Wind Speed=2.2m/s Wind Dir=20
+ ! Coldest Month=DEC
+ ! El Paso International Ap  Ut_TX_USA Annual Heating 99.6%, MaxDB=-5.2°C
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Htg 99.6% Condns DB,     !- Name
+         12,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+       -5.2,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       -5.2,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        2.2,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+         20,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Heating 99%, MaxDB=-3.1°C
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Htg 99% Condns DB,     !- Name
+         12,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+       -3.1,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       -3.1,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        2.2,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+         20,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Humidification 99.6% Design Conditions DP=>MCDB, DP=-17.7°C
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Hum_n 99.6% Condns DP=>MCDB,     !- Name
+         12,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+        5.6,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Dewpoint,     !- Humidity Condition Type
+      -17.7,      !- Dewpoint at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        2.2,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+         20,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Humidification 99% Design Conditions DP=>MCDB, DP=-15.5°C
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Hum_n 99% Condns DP=>MCDB,     !- Name
+         12,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+        7.8,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Dewpoint,     !- Humidity Condition Type
+      -15.5,      !- Dewpoint at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        2.2,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+         20,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Heating Wind 99.6% Design Conditions WS=>MCDB, WS=12.8m/s
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Htg Wind 99.6% Condns WS=>MCDB,     !- Name
+         12,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+       12.2,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       12.2,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+       12.8,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+         20,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Heating Wind 99% Design Conditions WS=>MCDB, WS=11m/s
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Htg Wind 99% Condns WS=>MCDB,     !- Name
+         12,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+       10.7,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       10.7,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+         11,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+         20,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! El Paso International Ap  Ut Annual Cooling Design Conditions Wind Speed=3.9m/s Wind Dir=280
+ ! Hottest Month=JUL
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (DB=>MWB) .4%, MaxDB=38.1°C MWB=18.1°C
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg .4% Condns DB=>MWB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       38.1,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       18.1,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (DB=>MWB) 1%, MaxDB=36.8°C MWB=18°C
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg 1% Condns DB=>MWB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       36.8,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+         18,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (DB=>MWB) 2%, MaxDB=35.5°C MWB=17.9°C
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg 2% Condns DB=>MWB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       35.5,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       17.9,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (WB=>MDB) .4%, MDB=30.1°C WB=21.3°C
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg .4% Condns WB=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       30.1,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       21.3,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (WB=>MDB) 1%, MDB=29.6°C WB=20.7°C
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg 1% Condns WB=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       29.6,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       20.7,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (WB=>MDB) 2%, MDB=29.2°C WB=20.3°C
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg 2% Condns WB=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       29.2,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       20.3,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (DP=>MDB) .4%, MDB=22.8°C DP=19.4°C HR=0.0164
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg .4% Condns DP=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       22.8,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Dewpoint,     !- Humidity Condition Type
+       19.4,      !- Dewpoint at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (DP=>MDB) 1%, MDB=22.8°C DP=18.7°C HR=0.0156
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg 1% Condns DP=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       22.8,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Dewpoint,     !- Humidity Condition Type
+       18.7,      !- Dewpoint at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (DP=>MDB) 2%, MDB=23.3°C DP=17.9°C HR=0.0149
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg 2% Condns DP=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       23.3,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Dewpoint,     !- Humidity Condition Type
+       17.9,      !- Dewpoint at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (Enthalpy=>MDB) .4%, MDB=30°C Enthalpy=67300.0J/kg
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg .4% Condns Enth=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+         30,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+   Enthalpy,      !- Humidity Condition Type
+           ,      !- Wetbulb or Dewpoint at Maximum Dry-Bulb
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+    67300.0,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (Enthalpy=>MDB) 1%, MDB=29.2°C Enthalpy=65500.0J/kg
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg 1% Condns Enth=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       29.2,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+   Enthalpy,      !- Humidity Condition Type
+           ,      !- Wetbulb or Dewpoint at Maximum Dry-Bulb
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+    65500.0,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! El Paso International Ap  Ut_TX_USA Annual Cooling (Enthalpy=>MDB) 2%, MDB=29°C Enthalpy=63800.0J/kg
+ SizingPeriod:DesignDay,
+  El Paso International Ap  Ut Ann Clg 2% Condns Enth=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+         29,      !- Maximum Dry-Bulb Temperature {C}
+         13,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+   Enthalpy,      !- Humidity Condition Type
+           ,      !- Wetbulb or Dewpoint at Maximum Dry-Bulb
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+    63800.0,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     87865.,      !- Barometric Pressure {Pa}
+        3.9,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        280,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.605,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      1.547;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 

--- a/spec/files/osws/osm_suite.osw
+++ b/spec/files/osws/osm_suite.osw
@@ -1,30 +1,37 @@
 {
-	"seed_file": null,
-	"weather_file": null,
-	"measure_paths": [
+    "seed_file": null,
+    "weather_file": null,
+    "measure_paths": [
+    "../../../lib/measures",
     "../../files/measures"
-  ],
-	"file_paths": [
+    ],
+    "file_paths": [
     ".",
     "../../files/osms/in",
     "../../files/epws",
     ""
-  ],
-	"run_directory": null,
-	"steps": [
+    ],
+    "run_directory": null,
+    "steps": [
+    {
+      "measure_dir_name": "tbd_monkey_patch",
+      "arguments": {
+        "__SKIP__": false
+      }
+    },
     {
       "measure_dir_name": "tbd",
       "arguments": {
         "__SKIP__": false,
         "option": "poor (BETBG)"
       }
-		},
+    },
     {
       "measure_dir_name": "openstudio_results",
       "arguments": {
       }
-		}
-	],
-	"name": "Test File",
-	"description": "Test File"
+    }
+    ],
+    "name": "Test File",
+    "description": "Test File"
 }

--- a/spec/files/osws/prototype_suite.osw
+++ b/spec/files/osws/prototype_suite.osw
@@ -1,16 +1,23 @@
 {
-	"seed_file": null,
-	"weather_file": "CAN_PQ_Quebec.717140_CWEC.epw",
-	"measure_paths": [
+    "seed_file": null,
+    "weather_file": "CAN_PQ_Quebec.717140_CWEC.epw",
+    "measure_paths": [
+    "../../../lib/measures",
     "../../files/measures"
-  ],
-	"file_paths": [
+    ],
+    "file_paths": [
     ".",
     "../../files/epws",
     ""
-  ],
-	"run_directory": null,
-	"steps": [
+    ],
+    "run_directory": null,
+    "steps": [
+    {
+      "measure_dir_name": "tbd_monkey_patch",
+      "arguments": {
+        "__SKIP__": false
+      }
+    },
     {
       "measure_dir_name": "create_DOE_prototype_building",
       "arguments": {
@@ -19,20 +26,20 @@
         "climate_zone": "ASHRAE 169-2013-3B",
         "epw_file": "Not Applicable"
       }
-		},
+    },
     {
       "measure_dir_name": "tbd",
       "arguments": {
         "__SKIP__": false,
         "option": "poor (BETBG)"
       }
-		},
+    },
     {
       "measure_dir_name": "openstudio_results",
       "arguments": {
       }
-		}
-	],
-	"name": "Test File",
-	"description": "Test File"
+    }
+    ],
+    "name": "Test File",
+    "description": "Test File"
 }

--- a/spec/tbd_prototype_suite_spec.rb
+++ b/spec/tbd_prototype_suite_spec.rb
@@ -92,20 +92,27 @@ RSpec.describe TBD_Tests do
     Parallel.each(combos, in_threads: nproc) do |combo| # run E+ simulations
       type  = combo[0]
       opt   = combo[1]
-      id    = "#{type}_#{opt.gsub('|','-').gsub(' ', '-')}"
+      id    = "#{type}_#{opt.gsub(/[|\s\.]/, '-')}"
       dir   = File.join(runs, id)
       next if File.exist?(dir) && File.exist?(File.join(dir, "out.osw"))
 
       FileUtils.mkdir_p(dir)
       osw = Marshal.load( Marshal.dump(template) )
 
-      osw[:steps][0][:arguments][:building_type] = type
-      osw[:steps][1][:arguments][:__SKIP__     ] = true    if opt == "skip"
-      osw[:steps][1][:arguments][:option       ] = opt unless opt == "skip"
+      osw[:steps][1][:arguments][:building_type] = type
+      osw[:steps][2][:arguments][:__SKIP__     ] = true    if opt == "skip"
+      osw[:steps][2][:arguments][:option       ] = opt unless opt == "skip"
+
+      # use classic command in 3.7.0 for off by one error in OSW results:
+      # https://github.com/NREL/OpenStudio/issues/5140
+      classic = ''
+      if OpenStudio::openStudioVersion == '3.7.0'
+        classic = 'classic'
+      end
 
       file    = File.join(dir, "in.osw")
       File.open(file, "w") { |f| f << JSON.pretty_generate(osw) }
-      command = "'#{OpenStudio::getOpenStudioCLI}' run -w '#{file}'"
+      command = "'#{OpenStudio::getOpenStudioCLI}' #{classic} run -w '#{file}'"
       puts "... running CASE #{type} | #{opt}"
       stdout, stderr, status = Open3.capture3(clean, command)
       if !status.success?
@@ -121,7 +128,7 @@ RSpec.describe TBD_Tests do
       results = {}
 
       opts.each do |opt|
-        id   = "#{type}_#{opt.gsub('|','-').gsub(' ', '-')}"
+        id   = "#{type}_#{opt.gsub(/[|\s\.]/, '-')}"
         file = File.join(runs, id, "out.osw")
 
         results[opt] = {}
@@ -133,8 +140,8 @@ RSpec.describe TBD_Tests do
 
       opts.each do |opt|
         expect(results[opt][:completed_status]).to eq("Success")
-        res  = results[opt][:steps][1][:result]
-        os   = results[opt][:steps][2][:result]
+        res  = results[opt][:steps][2][:result]
+        os   = results[opt][:steps][3][:result]
         gj   = os[:step_values].select{ |v| v[:name] == "total_site_energy" }
         puts " ------       CASE  : #{type}"
         puts "        TBD option  : #{opt}"

--- a/spec/tbd_prototype_suite_spec.rb
+++ b/spec/tbd_prototype_suite_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe TBD_Tests do
 
     FileUtils.mkdir_p(runs)
     nproc    = [1, Parallel.processor_count - 2].max # nb processors to use
+    #nproc = 1
     template = nil
 
     File.open(osw_, "r") do |f|
@@ -91,7 +92,7 @@ RSpec.describe TBD_Tests do
     Parallel.each(combos, in_threads: nproc) do |combo| # run E+ simulations
       type  = combo[0]
       opt   = combo[1]
-      id    = "#{type}_#{opt}"
+      id    = "#{type}_#{opt.gsub('|','-').gsub(' ', '-')}"
       dir   = File.join(runs, id)
       next if File.exist?(dir) && File.exist?(File.join(dir, "out.osw"))
 
@@ -107,6 +108,11 @@ RSpec.describe TBD_Tests do
       command = "'#{OpenStudio::getOpenStudioCLI}' run -w '#{file}'"
       puts "... running CASE #{type} | #{opt}"
       stdout, stderr, status = Open3.capture3(clean, command)
+      if !status.success?
+        puts "Error running #{file}:"
+        puts stdout
+        puts stderr
+      end
     end
 
     puts
@@ -115,7 +121,7 @@ RSpec.describe TBD_Tests do
       results = {}
 
       opts.each do |opt|
-        id   = "#{type}_#{opt}"
+        id   = "#{type}_#{opt.gsub('|','-').gsub(' ', '-')}"
         file = File.join(runs, id, "out.osw")
 
         results[opt] = {}

--- a/spec/tbd_tests_spec.rb
+++ b/spec/tbd_tests_spec.rb
@@ -4193,7 +4193,7 @@ RSpec.describe TBD_Tests do
     # Before the fix, TBD labels these same edges as ":transition". In normal
     # circumstances, this wouldn't usually affect simulation results, as both
     # :transition and :ceiling PSI-factors would normally be set to 0.0 W/K per
-    # linear meter. But users remain free to reset either value ...
+    # linear meter. But users remain free to reset either value, so ...
     2.times do |time|
       unless time.zero?
         file  = File.join(__dir__, "files/osms/in/seb.osm")
@@ -4290,7 +4290,7 @@ RSpec.describe TBD_Tests do
       expect(surfaces.size).to eq(56)
       expect(io).to be_a(Hash)
       expect(io).to have_key(:edges)
-      expect(io[:edges].size).to eq(106) # not 80, if it were UNCONDITIONED
+      expect(io[:edges].size).to eq(106) # not 80 as if it were UNCONDITIONED
 
       edges = io[:edges]
       edges = edges.reject { |s| s.to_s.include?("sill"  ) }

--- a/spec/tbd_tests_spec.rb
+++ b/spec/tbd_tests_spec.rb
@@ -3893,7 +3893,7 @@ RSpec.describe TBD_Tests do
         expect(thzone.isVolumeAutocalculated).to be true
         expect(thzone.volume).to be_empty
 
-        plnum.surfaces.each_with_index do |s, i|
+        plnum.surfaces.each do |s|
           next if s.outsideBoundaryCondition.downcase == "outdoors"
 
           # If a SEB plenum surface isn't facing outdoors, it's 1 of 4 "floor"
@@ -4227,7 +4227,7 @@ RSpec.describe TBD_Tests do
         expect(thzone.isVolumeAutocalculated).to be true
         expect(thzone.volume).to be_empty
 
-        plnum.surfaces.each_with_index do |s, i|
+        plnum.surfaces.each do |s|
           next if s.outsideBoundaryCondition.downcase == "outdoors"
 
           # If a SEB plenum surface isn't facing outdoors, it's 1 of 4 "floor"

--- a/spec/tbd_tests_spec.rb
+++ b/spec/tbd_tests_spec.rb
@@ -1,13 +1,13 @@
 require "tbd"
 
 RSpec.describe TBD_Tests do
-  TOL  = TBD::TOL
-  TOL2 = TBD::TOL2
-  DBG  = TBD::DBG
-  INF  = TBD::INF
-  WRN  = TBD::WRN
-  ERR  = TBD::ERR
-  FTL  = TBD::FTL
+  TOL  = TBD::TOL.dup
+  TOL2 = TBD::TOL2.dup
+  DBG  = TBD::DBG.dup
+  INF  = TBD::INF.dup
+  WRN  = TBD::WRN.dup
+  ERR  = TBD::ERR.dup
+  FTL  = TBD::FTL.dup
 
   it "can process thermal bridging and derating: LoScrigno" do
     expect(TBD.level     ).to eq(INF)

--- a/spec/tbd_tests_spec.rb
+++ b/spec/tbd_tests_spec.rb
@@ -3867,6 +3867,12 @@ RSpec.describe TBD_Tests do
         expect(model).to_not be_empty
         model = model.get
 
+        # "Shading Surface 4" is overlapping with a plenum exterior wall.
+        sh4 = model.getShadingSurfaceByName("Shading Surface 4")
+        expect(sh4).to_not be_empty
+        sh4 = sh4.get
+        sh4.remove
+
         plnum = model.getSpaceByName("Level 0 Ceiling Plenum")
         expect(plnum).to_not be_empty
         plnum = plnum.get
@@ -3918,12 +3924,6 @@ RSpec.describe TBD_Tests do
             expect(TBD.same?(vertex, s.vertices.at(i))).to be true
           end
         end
-
-        # "Shading Surface 4" is also overlapping with a plenum exterior wall.
-        sh4 = model.getShadingSurfaceByName("Shading Surface 4")
-        expect(sh4).to_not be_empty
-        sh4 = sh4.get
-        sh4.remove
 
         # Save for future testing.
         file = File.join(__dir__, "files/osms/out/unconditioned2.osm")
@@ -4202,6 +4202,12 @@ RSpec.describe TBD_Tests do
         expect(model).to_not be_empty
         model = model.get
 
+        # "Shading Surface 4" is overlapping with a plenum exterior wall.
+        sh4 = model.getShadingSurfaceByName("Shading Surface 4")
+        expect(sh4).to_not be_empty
+        sh4 = sh4.get
+        sh4.remove
+
         plnum = model.getSpaceByName("Level 0 Ceiling Plenum")
         expect(plnum).to_not be_empty
         plnum = plnum.get
@@ -4253,12 +4259,6 @@ RSpec.describe TBD_Tests do
           end
         end
 
-        # "Shading Surface 4" is also overlapping with a plenum exterior wall.
-        sh4 = model.getShadingSurfaceByName("Shading Surface 4")
-        expect(sh4).to_not be_empty
-        sh4 = sh4.get
-        sh4.remove
-
         # Save for future testing.
         file = File.join(__dir__, "files/osms/out/seb2.osm")
         model.save(file, true)
@@ -4270,7 +4270,7 @@ RSpec.describe TBD_Tests do
           expect(plnum.isVolumeAutocalculated).to be true
         end
 
-        expect(plnum.volume.round(0)).to eq(50)
+        expect(plnum.volume.round(0)).to eq(50) # right answer
         expect(thzone.isVolumeDefaulted).to be true
         expect(thzone.isVolumeAutocalculated).to be true
         expect(thzone.volume).to be_empty

--- a/spec/tbd_tests_spec.rb
+++ b/spec/tbd_tests_spec.rb
@@ -13421,7 +13421,7 @@ RSpec.describe TBD_Tests do
     translator = OpenStudio::OSVersion::VersionTranslator.new
     TBD.clean!
 
-    msg   = "Empty 'polygon' (OSut::poly)"
+    msg   = "Empty 'polygon (non-collinears < 3)' (OSut::poly)"
     file  = File.join(__dir__, "files/osms/in/smalloffice.osm")
     path  = OpenStudio::Path.new(file)
     model = translator.loadModel(path)

--- a/tbd_tests.gemspec
+++ b/tbd_tests.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version    = [">= 2.5.0", "< 4"]
   s.metadata                 = {}
 
-  s.add_development_dependency "tbd",            "3.4.2"
+  s.add_development_dependency "tbd",            "3.4.3"
+  s.add_development_dependency "osut",           "0.6.0"
   s.add_development_dependency "json-schema", "~> 4"
   s.add_development_dependency "rake",        "~> 13.0"
   s.add_development_dependency "rspec",       "~> 3.11"

--- a/tbd_tests.gemspec
+++ b/tbd_tests.gemspec
@@ -27,8 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version    = [">= 2.5.0", "< 4"]
   s.metadata                 = {}
 
-  s.add_development_dependency "tbd",            "3.4.3"
-  s.add_development_dependency "osut",           "0.6.0"
+  s.add_development_dependency "tbd",         "3.4.3"
   s.add_development_dependency "json-schema", "~> 4"
   s.add_development_dependency "rake",        "~> 13.0"
   s.add_development_dependency "rspec",       "~> 3.11"


### PR DESCRIPTION
The v1.11.5 (2016) _seb.osm_, shipped with OpenStudio, holds plenum floors (i.e. ceiling tiles) typed as "RoofCeiling". This may have been considered OK several years ago, yet would be frowned upon today. This generates quite a few issues with more recent OpenStudio and EnergyPlus versions, as well as gems like _OSut_.

The _seb.osm_ also holds a shading surface, "_Shading Surface 4_", which is clearly overlapping one of the plenum outdoor-facing walls. 

This PR checks the outcome (e.g. can OpenStudio autocalculate space volume? impact on annual GJ?) of suggested fixes, pre- vs post-TBD derating. These fixes will likely be ported to other repos like _TBD_ and _OSut_. May file an OpenStudio enhancement request to offer a (2nd) fixed version of the seb.osm file.